### PR TITLE
Updated MAC of ffs-001999a72dba

### DIFF
--- a/vpn03/peers/ffs-001999a72dba
+++ b/vpn03/peers/ffs-001999a72dba
@@ -1,3 +1,3 @@
-#MAC: 00:e0:4c:e0:b6:d7
-#Hostname: ffs-00e04ce0b6d7
+#MAC: 00:19:99:a7:2d:ba
+#Hostname: ffs-001999a72dba
 key "402d0c3ffd3af3c3c5fa6eb66ed85511b3ddc444437c29bddc904da862949914";


### PR DESCRIPTION
Now the MAC of the onboard NIC of the Futro S550-2 is used.
