### PR TITLE
Moved ffs-bietigheim-04 (legacy) to ffs-shack-mesh-only (segment01).

### DIFF
--- a/vpn01/peers/ffs-14cc20cd4f5c
+++ b/vpn01/peers/ffs-14cc20cd4f5c
@@ -1,3 +1,3 @@
 #MAC: 14:cc:20:cd:4f:5c
-#Hostname: ffs-bietigheim-04
+#Hostname: ffs-shack-mesh-only
 key "f7bc4ae3e5b319887171c581f66efe7d988cbcd55bfc6592c5e7550dba44d6bb";


### PR DESCRIPTION
Used an eventnode as a preliminary mesh-over-WIFI node inside the shackspace lounge.
