### PR TITLE
Added first Ubiquiti Rocket M2 Titanium.

### DIFF
--- a/vpn03/peers/ffs-68725121716c
+++ b/vpn03/peers/ffs-68725121716c
@@ -1,0 +1,3 @@
+#MAC: 68:72:51:21:71:6c
+#Hostname: ffs-68725121716c
+key "08539d38480cba338d5bbb1afdd7459c14f917b42c4aea5fd42a13dba94934d9";


### PR DESCRIPTION
Flashing TI.v6.0.0-OpenWrt-r2400+38-a245772 from https://downloads.lede-project.org/snapshots/targets/ar71xx/generic/lede-ar71xx-generic-ubnt-rocket-m-ti-squashfs-factory.bin and then flashing a experimental build with freifunk-gluon/gluon#943